### PR TITLE
`getKeys` upstream backport

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1062,6 +1062,15 @@ API.prototype.getPrivKeyExternalSourceName = function() {
 };
 
 /**
+ * Returns unencrypted extended private key and mnemonics
+ *
+ * @param password
+ */
+API.prototype.getKeys = function(password) {
+  return this.credentials.getKeys(password);
+};
+
+/**
  * unlocks the private key. `lock` need to be called explicity
  * later to remove the unencrypted private key.
  *

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -359,6 +359,27 @@ Credentials.prototype.unlock = function(password) {
   }
 };
 
+Credentials.prototype.getKeys = function(password) {
+  var keys = {};
+
+  if (this.isPrivKeyEncrypted()) {
+    $.checkArgument(password, 'Private keys are encrypted, a password is needed');
+    try {
+      keys.xPrivKey = sjcl.decrypt(password, this.xPrivKeyEncrypted);
+
+      if (this.mnemonicEncrypted) {
+        keys.mnemonic = sjcl.decrypt(password, this.mnemonicEncrypted);
+      }
+    } catch (ex) {
+      throw new Error('Could not decrypt');
+    }
+  } else {
+    keys.xPrivKey = this.xPrivKey;
+    keys.mnemonic = this.mnemonic;
+  }
+  return keys;
+};
+
 Credentials.prototype.addPublicKeyRing = function(publicKeyRing) {
   this.publicKeyRing = _.clone(publicKeyRing);
 };
@@ -404,7 +425,7 @@ Credentials.prototype.clearMnemonic = function() {
 
 Credentials.fromOldCopayWallet = function(w) {
   function walletPrivKeyFromOldCopayWallet(w) {
-    // IN BWS, the master Pub Keys are not sent to the server, 
+    // IN BWS, the master Pub Keys are not sent to the server,
     // so it is safe to use them as seed for wallet's shared secret.
     var seed = w.publicKeyRing.copayersExtPubKeys.sort().join('');
     var seedBuf = new Buffer(seed);
@@ -430,7 +451,7 @@ Credentials.fromOldCopayWallet = function(w) {
       requestDerivation = (new Bitcore.HDPrivateKey(credentials.xPrivKey))
         .derive(path).hdPublicKey;
     } else {
-      // this 
+      // this
       var path = Constants.PATHS.REQUEST_KEY_AUTH;
       requestDerivation = (new Bitcore.HDPublicKey(xPubStr)).derive(path);
     }


### PR DESCRIPTION
Backported getKeys() from upstream master to make it compatible with Copay